### PR TITLE
Support for setting $CFG->reverseproxy Moodle option

### DIFF
--- a/3.0.10/README.md
+++ b/3.0.10/README.md
@@ -49,6 +49,7 @@ It is recommended to set them properly and not use default values.
 | PHPFPM_UPLOAD_MAX_FILESIZE | 2M | Maximum allowed upload filesize for PHP-FPM | TRUE |
 | CRON_MOODLE_INTERVAL | 15 | Interval for Moodle Cron in Minutes | TRUE |
 | MOODLECFG_SSLPROXY | false | Set to true if an SSL proxy container is put infront of the Moodle install, such as HAProxy with SSL termination. An example will be presented in the below docker compose files. | TRUE |
+| MOODLECFG_REVERSEPROXY | false | Set to true if the container is accessed via different base URL. This will prevent redirection loop if the container behind a proxy which strips the url. | TRUE |
 | MOODLE_LANG | en | ------ | FALSE |
 | MOODLE_WWWROOT | http://localhost | Be sure to update to https:// if an SSL proxy is used. | TRUE |
 | MOODLE_DBTYPE | pgsql | Change to `mysqli` if using MySQL | FALSE |

--- a/3.0.10/install-moodle.sh
+++ b/3.0.10/install-moodle.sh
@@ -5,6 +5,7 @@ NGINX_MAX_BODY_SIZE=${NGINX_MAX_BODY_SIZE:='1M'}
 PHPFPM_UPLOAD_MAX_FILESIZE=${PHPFPM_UPLOAD_MAX_FILESIZE:='2M'}
 CRON_MOODLE_INTERVAL=${CRON_MOODLE_INTERVAL:='15'}
 MOODLECFG_SSLPROXY=${MOODLECFG_SSLPROXY:='false'}
+MOODLECFG_REVERSEPROXY=${MOODLECFG_REVERSEPROXY:='false'}
 
 MOODLE_LANG=${MOODLE_LANG:='en'}
 MOODLE_WWWROOT=${MOODLE_WWWROOT:='http://localhost'}
@@ -53,7 +54,9 @@ chown -R www-data:www-data /var/www/html
 if [ -f /var/www/moodledata/do_not_remove ]; then
  echo "[install-moodle.sh] Breadcrumb file exists, Moodle is probably already installed but missing the config. Recreated config. Self-destructing and exiting."
  sed -i "/\\\*sslproxy\\\*/,+1 d" /var/www/html/config.php
- sed -i "/\\\*wwwroot\\\*/i \$CFG->sslproxy = $MOODLECFG_SSLPROXY;\n" /var/www/html/config.php
+ sed -i "/\\\*wwwroot\\\*/i \$CFG->sslproxy = $MOODLECFG_SSLPROXY;" /var/www/html/config.php
+ sed -i "/\\\*reverseproxy\\\*/,+1 d" /var/www/html/config.php
+ sed -i "/\\\*wwwroot\\\*/i \$CFG->reverseproxy = $MOODLECFG_REVERSEPROXY;\n" /var/www/html/config.php
  rm -- "$0" && exit 0
 fi
 
@@ -64,7 +67,8 @@ echo "*/$CRON_MOODLE_INTERVAL * * * * /usr/bin/php /var/www/html/admin/cli/cron.
 echo "Presence of this file will prevent execution of the docker install-moodle.sh script if the container is recreated." > /var/www/moodledata/do_not_remove
 
 #Reset some configs with new user defined values (SSL Proxy, Upload Sizes) that are baked in if the container is destroyed
-sed -i "/\\\*wwwroot\\\*/i \$CFG->sslproxy = $MOODLECFG_SSLPROXY;\n" /var/www/html/config.php
+sed -i "/\\\*wwwroot\\\*/i \$CFG->sslproxy = $MOODLECFG_SSLPROXY;" /var/www/html/config.php
+sed -i "/\\\*wwwroot\\\*/i \$CFG->reverseproxy = $MOODLECFG_REVERSEPROXY;\n" /var/www/html/config.php
 sed -i "/types_hash_max_size 2048;/a \\\tclient_max_body_size $NGINX_MAX_BODY_SIZE;" /etc/nginx/nginx.conf
 sed -i "s/upload_max_filesize = 2M/upload_max_filesize = $PHPFPM_UPLOAD_MAX_FILESIZE/g" /etc/php/7.0/fpm/php.ini
 

--- a/3.3.4+/README.md
+++ b/3.3.4+/README.md
@@ -49,6 +49,7 @@ It is recommended to set them properly and not use default values.
 | PHPFPM_UPLOAD_MAX_FILESIZE | 2M | Maximum allowed upload filesize for PHP-FPM | TRUE |
 | CRON_MOODLE_INTERVAL | 15 | Interval for Moodle Cron in Minutes | TRUE |
 | MOODLECFG_SSLPROXY | false | Set to true if an SSL proxy container is put infront of the Moodle install, such as HAProxy with SSL termination. An example will be presented in the below docker compose files. | TRUE |
+| MOODLECFG_REVERSEPROXY | false | Set to true if the container is accessed via different base URL. This will prevent redirection loop if the container behind a proxy which strips the url. | TRUE |
 | MOODLE_LANG | en | ------ | FALSE |
 | MOODLE_WWWROOT | http://localhost | Be sure to update to https:// if an SSL proxy is used. | TRUE |
 | MOODLE_DBTYPE | pgsql | Change to `mysqli` if using MySQL | FALSE |

--- a/3.3.4+/install-moodle.sh
+++ b/3.3.4+/install-moodle.sh
@@ -5,6 +5,7 @@ NGINX_MAX_BODY_SIZE=${NGINX_MAX_BODY_SIZE:='1M'}
 PHPFPM_UPLOAD_MAX_FILESIZE=${PHPFPM_UPLOAD_MAX_FILESIZE:='2M'}
 CRON_MOODLE_INTERVAL=${CRON_MOODLE_INTERVAL:='15'}
 MOODLECFG_SSLPROXY=${MOODLECFG_SSLPROXY:='false'}
+MOODLECFG_REVERSEPROXY=${MOODLECFG_REVERSEPROXY:='false'}
 
 MOODLE_LANG=${MOODLE_LANG:='en'}
 MOODLE_WWWROOT=${MOODLE_WWWROOT:='http://localhost'}
@@ -53,7 +54,9 @@ chown -R www-data:www-data /var/www/html
 if [ -f /var/www/moodledata/do_not_remove ]; then
  echo "[install-moodle.sh] Breadcrumb file exists, Moodle is probably already installed but missing the config. Recreated config. Self-destructing and exiting."
  sed -i "/\\\*sslproxy\\\*/,+1 d" /var/www/html/config.php
- sed -i "/\\\*wwwroot\\\*/i \$CFG->sslproxy = $MOODLECFG_SSLPROXY;\n" /var/www/html/config.php
+ sed -i "/\\\*wwwroot\\\*/i \$CFG->sslproxy = $MOODLECFG_SSLPROXY;" /var/www/html/config.php
+ sed -i "/\\\*reverseproxy\\\*/,+1 d" /var/www/html/config.php
+ sed -i "/\\\*wwwroot\\\*/i \$CFG->reverseproxy = $MOODLECFG_REVERSEPROXY;\n" /var/www/html/config.php
  rm -- "$0" && exit 0
 fi
 
@@ -64,7 +67,8 @@ echo "*/$CRON_MOODLE_INTERVAL * * * * /usr/bin/php /var/www/html/admin/cli/cron.
 echo "Presence of this file will prevent execution of the docker install-moodle.sh script if the container is recreated." > /var/www/moodledata/do_not_remove
 
 #Reset some configs with new user defined values (SSL Proxy, Upload Sizes) that are baked in if the container is destroyed
-sed -i "/\\\*wwwroot\\\*/i \$CFG->sslproxy = $MOODLECFG_SSLPROXY;\n" /var/www/html/config.php
+sed -i "/\\\*wwwroot\\\*/i \$CFG->sslproxy = $MOODLECFG_SSLPROXY;" /var/www/html/config.php
+sed -i "/\\\*wwwroot\\\*/i \$CFG->reverseproxy = $MOODLECFG_REVERSEPROXY;\n" /var/www/html/config.php
 sed -i "/types_hash_max_size 2048;/a \\\tclient_max_body_size $NGINX_MAX_BODY_SIZE;" /etc/nginx/nginx.conf
 sed -i "s/upload_max_filesize = 2M/upload_max_filesize = $PHPFPM_UPLOAD_MAX_FILESIZE/g" /etc/php/7.0/fpm/php.ini
 

--- a/3.4.1+/README.md
+++ b/3.4.1+/README.md
@@ -49,6 +49,7 @@ It is recommended to set them properly and not use default values.
 | PHPFPM_UPLOAD_MAX_FILESIZE | 2M | Maximum allowed upload filesize for PHP-FPM | TRUE |
 | CRON_MOODLE_INTERVAL | 15 | Interval for Moodle Cron in Minutes | TRUE |
 | MOODLECFG_SSLPROXY | false | Set to true if an SSL proxy container is put infront of the Moodle install, such as HAProxy with SSL termination. An example will be presented in the below docker compose files. | TRUE |
+| MOODLECFG_REVERSEPROXY | false | Set to true if the container is accessed via different base URL. This will prevent redirection loop if the container behind a proxy which strips the url. | TRUE |
 | MOODLE_LANG | en | ------ | FALSE |
 | MOODLE_WWWROOT | http://localhost | Be sure to update to https:// if an SSL proxy is used. | TRUE |
 | MOODLE_DBTYPE | pgsql | Change to `mysqli` if using MySQL | FALSE |

--- a/3.4.1+/install-moodle.sh
+++ b/3.4.1+/install-moodle.sh
@@ -5,6 +5,7 @@ NGINX_MAX_BODY_SIZE=${NGINX_MAX_BODY_SIZE:='1M'}
 PHPFPM_UPLOAD_MAX_FILESIZE=${PHPFPM_UPLOAD_MAX_FILESIZE:='2M'}
 CRON_MOODLE_INTERVAL=${CRON_MOODLE_INTERVAL:='15'}
 MOODLECFG_SSLPROXY=${MOODLECFG_SSLPROXY:='false'}
+MOODLECFG_REVERSEPROXY=${MOODLECFG_REVERSEPROXY:='false'}
 
 MOODLE_LANG=${MOODLE_LANG:='en'}
 MOODLE_WWWROOT=${MOODLE_WWWROOT:='http://localhost'}
@@ -53,7 +54,9 @@ chown -R www-data:www-data /var/www/html
 if [ -f /var/www/moodledata/do_not_remove ]; then
  echo "[install-moodle.sh] Breadcrumb file exists, Moodle is probably already installed but missing the config. Recreated config. Self-destructing and exiting."
  sed -i "/\\\*sslproxy\\\*/,+1 d" /var/www/html/config.php
- sed -i "/\\\*wwwroot\\\*/i \$CFG->sslproxy = $MOODLECFG_SSLPROXY;\n" /var/www/html/config.php
+ sed -i "/\\\*wwwroot\\\*/i \$CFG->sslproxy = $MOODLECFG_SSLPROXY;" /var/www/html/config.php
+ sed -i "/\\\*reverseproxy\\\*/,+1 d" /var/www/html/config.php
+ sed -i "/\\\*wwwroot\\\*/i \$CFG->reverseproxy = $MOODLECFG_REVERSEPROXY;\n" /var/www/html/config.php
  rm -- "$0" && exit 0
 fi
 
@@ -64,7 +67,8 @@ echo "*/$CRON_MOODLE_INTERVAL * * * * /usr/bin/php /var/www/html/admin/cli/cron.
 echo "Presence of this file will prevent execution of the docker install-moodle.sh script if the container is recreated." > /var/www/moodledata/do_not_remove
 
 #Reset some configs with new user defined values (SSL Proxy, Upload Sizes) that are baked in if the container is destroyed
-sed -i "/\\\*wwwroot\\\*/i \$CFG->sslproxy = $MOODLECFG_SSLPROXY;\n" /var/www/html/config.php
+sed -i "/\\\*wwwroot\\\*/i \$CFG->sslproxy = $MOODLECFG_SSLPROXY;" /var/www/html/config.php
+sed -i "/\\\*wwwroot\\\*/i \$CFG->reverseproxy = $MOODLECFG_REVERSEPROXY;\n" /var/www/html/config.php
 sed -i "/types_hash_max_size 2048;/a \\\tclient_max_body_size $NGINX_MAX_BODY_SIZE;" /etc/nginx/nginx.conf
 sed -i "s/upload_max_filesize = 2M/upload_max_filesize = $PHPFPM_UPLOAD_MAX_FILESIZE/g" /etc/php/7.0/fpm/php.ini
 


### PR DESCRIPTION
This will enable the case when the container is behind a reverse proxy
which publish moodle on url other than '/' (e.g. www.example.com/courses)